### PR TITLE
Switch to vanity import path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .PHONY: generate
 generate:
 	@ go generate ./...
+	@ go list -m -json all | go run main.go -noticeOut=NOTICE
 
 .PHONY: build
 build: generate

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-Copyright 2018-2020 Elasticsearch BV
+Copyright 2019-2020 Elasticsearch BV
 
 This product includes software developed by The Apache Software
 Foundation (http://www.apache.org/).
@@ -291,6 +291,37 @@ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
 CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+--------------------------------------------------------------------------------
+Module  : github.com/markbates/pkger
+Version : v0.15.1
+Time    : 2020-04-03T14:58:08Z
+Licence : MIT
+
+Contents of probable licence file $GOMODCACHE/github.com/markbates/pkger@v0.15.1/LICENSE:
+
+The MIT License (MIT)
+
+Copyright (c) 2019 Mark Bates
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 
 --------------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@ Go Licence Detector
 
 This is a tool designed to generate licence notices and dependency listings for Go projects at Elastic. It parses the output of `go list -m -json all` to produce its output.
 
+```
+go get go.elastic.co/go-licence-detector
+```
 
 ## Usage
 

--- a/dependency/dependency.go
+++ b/dependency/dependency.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package dependency
+package dependency // import "go.elastic.co/go-licence-detector/dependency"
 
 import (
 	"encoding/json"

--- a/detector/detector.go
+++ b/detector/detector.go
@@ -15,9 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//go:generate pkger -include=github.com/elastic/go-licence-detector:/assets -o=detector
+//go:generate pkger -include=go.elastic.co/go-licence-detector:/assets -o=detector
 
-package detector
+package detector // import "go.elastic.co/go-licence-detector/detector"
 
 import (
 	"encoding/json"
@@ -30,16 +30,16 @@ import (
 	"strings"
 	"time"
 
-	"github.com/elastic/go-licence-detector/dependency"
 	"github.com/google/licenseclassifier"
 	"github.com/karrick/godirwalk"
 	"github.com/markbates/pkger"
+	"go.elastic.co/go-licence-detector/dependency"
 )
 
 const (
 	// detectionThreshold is the minimum confidence score required from the licence classifier.
 	detectionThreshold = 0.85
-	licenceDBPath      = "github.com/elastic/go-licence-detector:/assets/licence.db"
+	licenceDBPath      = "go.elastic.co/go-licence-detector:/assets/licence.db"
 )
 
 var errLicenceNotFound = errors.New("failed to detect licence")

--- a/detector/detector_test.go
+++ b/detector/detector_test.go
@@ -21,8 +21,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/elastic/go-licence-detector/dependency"
 	"github.com/stretchr/testify/require"
+	"go.elastic.co/go-licence-detector/dependency"
 )
 
 func TestDetect(t *testing.T) {
@@ -56,8 +56,8 @@ func TestDetect(t *testing.T) {
 			name:            "WithOverrides",
 			includeIndirect: true,
 			overrides: map[string]dependency.Info{
-				"github.com/davecgh/go-spew":         dependency.Info{Name: "github.com/davecgh/go-spew", URL: "http://example.com/go-spew"},
-				"github.com/russross/blackfriday/v2": dependency.Info{Name: "github.com/russross/blackfriday/v2", LicenceType: "MIT"},
+				"github.com/davecgh/go-spew":         {Name: "github.com/davecgh/go-spew", URL: "http://example.com/go-spew"},
+				"github.com/russross/blackfriday/v2": {Name: "github.com/russross/blackfriday/v2", LicenceType: "MIT"},
 			},
 			wantDependencies: func() *dependency.List {
 				deps := &dependency.List{}
@@ -85,8 +85,8 @@ func TestDetect(t *testing.T) {
 			name:            "WithInvalidLicenceFileOverride",
 			includeIndirect: true,
 			overrides: map[string]dependency.Info{
-				"github.com/davecgh/go-spew":         dependency.Info{Name: "github.com/davecgh/go-spew", LicenceFile: "/path/to/nowhere"},
-				"github.com/russross/blackfriday/v2": dependency.Info{Name: "github.com/russross/blackfriday/v2", LicenceFile: "/path/to/nowhere"},
+				"github.com/davecgh/go-spew":         {Name: "github.com/davecgh/go-spew", LicenceFile: "/path/to/nowhere"},
+				"github.com/russross/blackfriday/v2": {Name: "github.com/russross/blackfriday/v2", LicenceFile: "/path/to/nowhere"},
 			},
 			wantErr: true,
 		},
@@ -95,9 +95,9 @@ func TestDetect(t *testing.T) {
 			name:            "LicenceNotWhitelisted",
 			includeIndirect: true,
 			overrides: map[string]dependency.Info{
-				"github.com/davecgh/go-spew":         dependency.Info{Name: "github.com/davecgh/go-spew", LicenceType: "Totally Legit License 2.0"},
-				"github.com/russross/blackfriday/v2": dependency.Info{Name: "github.com/russross/blackfriday/v2", LicenceType: "MIT"},
-				"github.com/davecgh/go-gk":           dependency.Info{Name: "github.com/davecgh/go-spew", LicenceType: "UNKNOWN"},
+				"github.com/davecgh/go-spew":         {Name: "github.com/davecgh/go-spew", LicenceType: "Totally Legit License 2.0"},
+				"github.com/russross/blackfriday/v2": {Name: "github.com/russross/blackfriday/v2", LicenceType: "MIT"},
+				"github.com/davecgh/go-gk":           {Name: "github.com/davecgh/go-spew", LicenceType: "UNKNOWN"},
 			},
 			wantErr: true,
 		},

--- a/detector/rules.go
+++ b/detector/rules.go
@@ -27,7 +27,7 @@ import (
 	"github.com/markbates/pkger"
 )
 
-const embeddedRulesFile = "github.com/elastic/go-licence-detector:/assets/rules.json"
+const embeddedRulesFile = "go.elastic.co/go-licence-detector:/assets/rules.json"
 
 // rulesFile represents the structure of the rules file.
 type rulesFile struct {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/elastic/go-licence-detector
+module go.elastic.co/go-licence-detector
 
 go 1.13
 

--- a/main.go
+++ b/main.go
@@ -24,10 +24,10 @@ import (
 	"log"
 	"os"
 
-	"github.com/elastic/go-licence-detector/dependency"
-	"github.com/elastic/go-licence-detector/detector"
-	"github.com/elastic/go-licence-detector/render"
-	"github.com/elastic/go-licence-detector/validate"
+	"go.elastic.co/go-licence-detector/dependency"
+	"go.elastic.co/go-licence-detector/detector"
+	"go.elastic.co/go-licence-detector/render"
+	"go.elastic.co/go-licence-detector/validate"
 )
 
 var (

--- a/render/render.go
+++ b/render/render.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package render
+package render // import "go.elastic.co/go-licence-detector/render"
 
 import (
 	"bytes"
@@ -30,7 +30,7 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/elastic/go-licence-detector/dependency"
+	"go.elastic.co/go-licence-detector/dependency"
 )
 
 var goModCache = filepath.Join(build.Default.GOPATH, "pkg", "mod")

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package validate
+package validate // import "go.elastic.co/go-licence-detector/validate"
 
 import (
 	"context"
@@ -29,7 +29,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/elastic/go-licence-detector/dependency"
+	"go.elastic.co/go-licence-detector/dependency"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/validate/validate_test.go
+++ b/validate/validate_test.go
@@ -25,8 +25,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/elastic/go-licence-detector/dependency"
 	"github.com/stretchr/testify/require"
+	"go.elastic.co/go-licence-detector/dependency"
 )
 
 func TestValidateURLs(t *testing.T) {


### PR DESCRIPTION
Switch to `go.elastic.co/go-licence-detector` vanity import path.

Also includes some fixes to formatting issues detected during the refactoring.