### PR TITLE
Make -noticeTemplate optional

### DIFF
--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ var (
 	inFlag              = flag.String("in", "-", "Dependency list (output from go list -m -json all).")
 	includeIndirectFlag = flag.Bool("includeIndirect", false, "Include indirect dependencies.")
 	licenceDataFlag     = flag.String("licenceData", "", "Path to the licence database. Uses embedded database if empty.")
-	noticeTemplateFlag  = flag.String("noticeTemplate", "example/templates/NOTICE.txt.tmpl", "Path to the NOTICE template file.")
+	noticeTemplateFlag  = flag.String("noticeTemplate", "", "Path to the NOTICE template file.")
 	noticeOutFlag       = flag.String("noticeOut", "", "Path to output the notice.")
 	overridesFlag       = flag.String("overrides", "", "Path to the file containing override directives.")
 	rulesFlag           = flag.String("rules", "", "Path to file containing rules regarding licence types. Uses embedded rules if empty.")
@@ -85,8 +85,14 @@ func main() {
 
 	// only generate notice file if the output path is provided
 	if *noticeOutFlag != "" {
-		if err := render.Template(dependencies, *noticeTemplateFlag, *noticeOutFlag); err != nil {
-			log.Fatalf("Failed to render notice: %v", err)
+		if *noticeTemplateFlag != "" {
+			if err := render.Template(dependencies, *noticeTemplateFlag, *noticeOutFlag); err != nil {
+				log.Fatalf("Failed to render notice: %v", err)
+			}
+		} else {
+			if err := render.TemplateFromDefaultNotice(dependencies, *noticeOutFlag); err != nil {
+				log.Fatalf("Failed to render notice from default template: %v", err)
+			}
 		}
 	}
 

--- a/render/render.go
+++ b/render/render.go
@@ -47,7 +47,7 @@ func Template(dependencies *dependency.List, templatePath, outputPath string) er
 func TemplateFromDefaultNotice(dependencies *dependency.List, outputPath string) error {
 	tmpl, err := template.New("NOTICE.txt").Funcs(funcMap()).Parse(noticeTxt)
 	if err != nil {
-		return fmt.Errorf("failed to parse default template at: %w", err)
+		return fmt.Errorf("failed to parse default template: %w", err)
 	}
 
 	return writeTemplateToFile(tmpl, dependencies, outputPath)

--- a/render/template.go
+++ b/render/template.go
@@ -1,0 +1,52 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package render
+
+const (
+	noticeTxt = `
+{{- define "depInfo" -}}
+{{- range $i, $dep := . }}
+{{ "-" | line }}
+Module  : {{ $dep.Name }}
+Version : {{ $dep.Version }}
+Time    : {{ $dep.VersionTime }}
+Licence : {{ $dep.LicenceType }}
+
+{{ $dep | licenceText }}
+{{ end }}
+{{- end -}}
+
+Copyright 2019-{{ currentYear }} Elasticsearch BV
+
+This product includes software developed by The Apache Software
+Foundation (http://www.apache.org/).
+
+{{ "=" | line }}
+Third party libraries used by the go-licence-detector project
+{{ "=" | line }}
+
+{{ template "depInfo" .Direct }}
+
+{{ if .Indirect }}
+{{ "=" | line }}
+Indirect dependencies
+
+{{ template "depInfo" .Indirect }}
+{{ end }}
+`
+)


### PR DESCRIPTION
This PR makes the flag `-noticeTemplate` optional. Thus, repos which do not require specially formatted NOTICE.txt files, do not need to provide a template.