### PR TITLE
Unify new lines in notice file

### DIFF
--- a/render/render.go
+++ b/render/render.go
@@ -18,6 +18,7 @@
 package render // import "go.elastic.co/go-licence-detector/render"
 
 import (
+	"bufio"
 	"bytes"
 	"fmt"
 	"go/build"
@@ -154,8 +155,12 @@ func LicenceText(depInfo dependency.Info) string {
 	}
 	defer f.Close()
 
-	_, err = io.Copy(&buf, f)
-	if err != nil {
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		buf.WriteString(scanner.Text() + "\n")
+	}
+
+	if err := scanner.Err(); err != nil {
 		log.Fatalf("Failed to read licence file %s: %v", depInfo.LicenceFile, err)
 	}
 


### PR DESCRIPTION
Before this change, license files where copied as they are in their
original form. In some cases, these contain carriage return (CR) characters
(as you would expect in Windows machines). The rest of the file doesn't
contain it, as it's written by Go based on the local system.

Windows developers normally configure git to get rid of these characters
when commiting a file (see `core.autocrlf` setting for more details).
That will create a conflict at commit, as the CR character will be
removed from the notice files written by linux/mac.

This change copies license headers line by line, instead of doing a
binary copy, ensuring that the system newline char is respected in the
whole notice.