### PR TITLE
Handle relative module replacements

### DIFF
--- a/detector/detector_test.go
+++ b/detector/detector_test.go
@@ -192,6 +192,15 @@ func mkDirectDeps() []dependency.Info {
 			URL:         "https://github.com/ekzhu/minhash-lsh",
 		},
 		{
+			Name:        "github.com/elastic/test",
+			Version:     "v0.0.1",
+			VersionTime: "unknown",
+			Dir:         "testdata/github.com/elastic/test",
+			LicenceType: "MIT",
+			LicenceFile: "testdata/github.com/elastic/test/LICENSE.txt",
+			URL:         "https://github.com/elastic/test",
+		},
+		{
 			Name:        "github.com/russross/blackfriday/v2",
 			Version:     "v2.0.1",
 			VersionTime: "2018-09-20T17:16:15Z",
@@ -222,6 +231,15 @@ func mkDirectOverridenDeps() []dependency.Info {
 			LicenceType: "MIT",
 			LicenceFile: "testdata/github.com/ekzhu/minhash-lsh@v0.0.0-20171225071031-5c06ee8586a1/licence.txt",
 			URL:         "https://github.com/ekzhu/minhash-lsh",
+		},
+		{
+			Name:        "github.com/elastic/test",
+			Version:     "v0.0.1",
+			VersionTime: "unknown",
+			Dir:         "testdata/github.com/elastic/test",
+			LicenceType: "MIT",
+			LicenceFile: "testdata/github.com/elastic/test/LICENSE.txt",
+			URL:         "https://github.com/elastic/test",
 		},
 		{
 			Name:        "github.com/russross/blackfriday/v2",

--- a/detector/testdata/deps.json
+++ b/detector/testdata/deps.json
@@ -37,6 +37,18 @@
 	"GoMod": "testdata/cache/download/github.com/ekzhu/minhash-lsh/@v/v0.0.0-20171225071031-5c06ee8586a1.mod"
 }
 {
+	"Path": "github.com/elastic/test",
+	"Version": "v0.0.1",
+	"Replace": {
+		"Path": "../test",
+		"Version": "v0.0.1",
+		"Dir": "testdata/github.com/elastic/test",
+		"GoMod": "testdata/cache/download/github.com/elastic/test/go.mod"
+	},
+	"Dir": "testdata/github.com/elastic/test@v0.0.1",
+	"GoMod": "testdata/github.com/elastic/test@v0.0.1/go.mod"
+}
+{
 	"Path": "gopkg.in/russross/blackfriday.v2",
 	"Version": "v2.0.1",
 	"Replace": {

--- a/detector/testdata/github.com/elastic/test/LICENSE.txt
+++ b/detector/testdata/github.com/elastic/test/LICENSE.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2020 Elastic
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.


### PR DESCRIPTION
Relative module replacements don't have timestamps and cause nil pointer panics when trying to format time.

Fixes #11 