### PR TITLE
Add CC0-1.0 to the allowed licenses

### DIFF
--- a/assets/rules.json
+++ b/assets/rules.json
@@ -6,6 +6,7 @@
     "ISC",
     "MIT",
     "MPL-2.0",
-    "Public Domain"
+    "Public Domain",
+    "CC0-1.0"
   ]
 }


### PR DESCRIPTION
This PR adds [CC0 1.0 Universal (CC0 1.0)](https://creativecommons.org/publicdomain/zero/1.0/) to the list of allowed licenses.