### PR TITLE
Change handling, when no licence was found

### DIFF
--- a/detector/detector.go
+++ b/detector/detector.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"log"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -170,7 +171,8 @@ func doDetectLicences(licenceRegex *regexp.Regexp, classifier *licenseclassifier
 		// detect the licence type if the override hasn't provided one
 		if depInfo.LicenceType == "" {
 			if depInfo.LicenceFile == "" {
-				return nil, fmt.Errorf("no licence file found for %s. Add an override entry with licence type to continue.", depInfo.Name)
+				log.Printf("Skipping %s because no licence was found.", depInfo.Name)
+				continue
 			}
 
 			var err error
@@ -180,7 +182,8 @@ func doDetectLicences(licenceRegex *regexp.Regexp, classifier *licenseclassifier
 			}
 
 			if depInfo.LicenceType == "" {
-				return nil, fmt.Errorf("licence unknown for %s. Add an override entry with licence type to continue.", depInfo.Name)
+				log.Printf("Skipping %s because no licence was found.", depInfo.Name)
+				continue
 			}
 		}
 

--- a/detector/detector.go
+++ b/detector/detector.go
@@ -171,18 +171,19 @@ func doDetectLicences(licenceRegex *regexp.Regexp, classifier *licenseclassifier
 		// detect the licence type if the override hasn't provided one
 		if depInfo.LicenceType == "" {
 			if depInfo.LicenceFile == "" {
-				log.Printf("Skipping %s because no licence was found.", depInfo.Name)
+				log.Printf("Skipping %s because no licence was found.\n", depInfo.Name)
 				continue
 			}
 
 			var err error
 			depInfo.LicenceType, err = detectLicenceType(classifier, depInfo.LicenceFile)
 			if err != nil {
-				return nil, fmt.Errorf("failed to detect licence type of %s from %s: %w", depInfo.Name, depInfo.LicenceFile, err)
+				log.Printf("Failed to detect licence type of %s. Skipping it!\n", depInfo.Name)
+				//return nil, fmt.Errorf("failed to detect licence type of %s from %s: %w", depInfo.Name, depInfo.LicenceFile, err)
 			}
 
 			if depInfo.LicenceType == "" {
-				log.Printf("Skipping %s because no licence was found.", depInfo.Name)
+				log.Printf("Skipping %s because no licence was found.\n", depInfo.Name)
 				continue
 			}
 		}


### PR DESCRIPTION
In the current version of the go-licence-detector, the application will stop when no license can be found for a dependency. The error-message says, that an override entry will be added, so the application can continue. But in my case, the application ends at this point.

I have made an change, so that the application logs an information and continues. The dependency with the unknown license will be skipped and the application continues.