### PR TITLE
Add license.[a-z] filename to detector

### DIFF
--- a/detector/detector.go
+++ b/detector/detector.go
@@ -270,7 +270,7 @@ func buildLicenceRegex() *regexp.Regexp {
 	// inspired by https://github.com/src-d/go-license-detector/blob/7961dd6009019bc12778175ef7f074ede24bd128/licensedb/internal/investigation.go#L29
 	licenceFileNames := []string{
 		`li[cs]en[cs]es?`,
-		`license.(mit|apache)`,
+		`license.[a-z]{2,}`,
 		`legal`,
 		`copy(left|right|ing)`,
 		`unlicense`,


### PR DESCRIPTION
Cloudbeat has a dependency, https://github.com/spdx/tools-golang, with a license file named `LICENSE.docs` which is not supported.
In order to support this, the detector can now detect all files of the form `lisense.[a-z]{2,}` (case insensitive)