### PR TITLE
Allow additional template variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@ bin/
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+# editor and IDE paraphernalia
+.idea
+go-licence-detector.iml

--- a/dependency/dependency.go
+++ b/dependency/dependency.go
@@ -30,9 +30,8 @@ import (
 
 // List holds direct and indirect dependency information.
 type List struct {
-	Direct         []Info
-	Indirect       []Info
-	TemplateValues map[string]string
+	Direct   []Info
+	Indirect []Info
 }
 
 // Info holds information about a dependency.

--- a/dependency/dependency.go
+++ b/dependency/dependency.go
@@ -30,8 +30,9 @@ import (
 
 // List holds direct and indirect dependency information.
 type List struct {
-	Direct   []Info
-	Indirect []Info
+	Direct         []Info
+	Indirect       []Info
+	TemplateValues map[string]string
 }
 
 // Info holds information about a dependency.

--- a/main.go
+++ b/main.go
@@ -40,9 +40,12 @@ var (
 	overridesFlag       = flag.String("overrides", "", "Path to the file containing override directives.")
 	rulesFlag           = flag.String("rules", "", "Path to file containing rules regarding licence types. Uses embedded rules if empty.")
 	validateFlag        = flag.Bool("validate", false, "Validate results (slow).")
+
+	templateKeyValues render.KeyValueFlags
 )
 
 func main() {
+	flag.Var(&templateKeyValues, "template-value", "Can be used in template to pass in a version number or similar information. Example: --template-value=key1=value1 and {{index .TemplateValues \"key1\"}}.")
 	flag.Parse()
 
 	// create reader for dependency information
@@ -75,6 +78,8 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to detect licences: %v", err)
 	}
+	// inject template values
+	dependencies.TemplateValues = templateKeyValues.AsMap()
 
 	if *validateFlag {
 		if err := validate.Validate(dependencies); err != nil {

--- a/main.go
+++ b/main.go
@@ -78,8 +78,6 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to detect licences: %v", err)
 	}
-	// inject template values
-	dependencies.TemplateValues = templateKeyValues.AsMap()
 
 	if *validateFlag {
 		if err := validate.Validate(dependencies); err != nil {
@@ -89,14 +87,14 @@ func main() {
 
 	// only generate notice file if the output path is provided
 	if *noticeOutFlag != "" {
-		if err := render.Template(dependencies, *noticeTemplateFlag, *noticeOutFlag); err != nil {
+		if err := render.Template(dependencies, templateKeyValues, *noticeTemplateFlag, *noticeOutFlag); err != nil {
 			log.Fatalf("Failed to render notice: %v", err)
 		}
 	}
 
 	// only generate dependency listing if the output path is provided
 	if *depsOutFlag != "" {
-		if err := render.Template(dependencies, *depsTemplateFlag, *depsOutFlag); err != nil {
+		if err := render.Template(dependencies, templateKeyValues, *depsTemplateFlag, *depsOutFlag); err != nil {
 			log.Fatalf("Failed to render dependency list: %v", err)
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -45,7 +45,7 @@ var (
 )
 
 func main() {
-	flag.Var(&templateKeyValues, "template-value", "Can be used in template to pass in a version number or similar information. Example: --template-value=key1=value1 and {{index .TemplateValues \"key1\"}}.")
+	flag.Var(&templateKeyValues, "template-value", "Can be used in template to pass in a version number or similar information. Example: --template-value=key1=value1 and {{TemplateValue \"key1\"}}.")
 	flag.Parse()
 
 	// create reader for dependency information

--- a/render/kv.go
+++ b/render/kv.go
@@ -29,23 +29,27 @@ type KeyValue struct {
 type KeyValueFlags []KeyValue
 
 // KeyValue is an implementation of the flag.Value interface
-func (i *KeyValueFlags) String() string {
-	return fmt.Sprintf("%v", *i)
+func (kvs *KeyValueFlags) String() string {
+	if kvs == nil {
+		return ""
+	}
+	return fmt.Sprintf("%v", *kvs)
 }
 
-func (i *KeyValueFlags) AsMap() map[string]string {
-	if i == nil {
-		return nil
+func (kvs *KeyValueFlags) Get(key string) string {
+	if kvs == nil {
+		return ""
 	}
-	m := make(map[string]string, len(*i))
-	for _, kv := range *i {
-		m[kv.Key] = kv.Value
+	for _, kv := range *kvs {
+		if kv.Key == key {
+			return kv.Value
+		}
 	}
-	return m
+	return ""
 }
 
 // Set is an implementation of the flag.Value interface
-func (i *KeyValueFlags) Set(value string) error {
+func (kvs *KeyValueFlags) Set(value string) error {
 	if value == "" {
 		return nil
 	}
@@ -59,6 +63,6 @@ func (i *KeyValueFlags) Set(value string) error {
 		return fmt.Errorf("key and value must not be empty: %s", value)
 	}
 	kv := KeyValue{Key: key, Value: value}
-	*i = append(*i, kv)
+	*kvs = append(*kvs, kv)
 	return nil
 }

--- a/render/kv.go
+++ b/render/kv.go
@@ -1,0 +1,64 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package render
+
+import (
+	"fmt"
+	"strings"
+)
+
+type KeyValue struct {
+	Key   string
+	Value string
+}
+type KeyValueFlags []KeyValue
+
+// KeyValue is an implementation of the flag.Value interface
+func (i *KeyValueFlags) String() string {
+	return fmt.Sprintf("%v", *i)
+}
+
+func (i *KeyValueFlags) AsMap() map[string]string {
+	if i == nil {
+		return nil
+	}
+	m := make(map[string]string, len(*i))
+	for _, kv := range *i {
+		m[kv.Key] = kv.Value
+	}
+	return m
+}
+
+// Set is an implementation of the flag.Value interface
+func (i *KeyValueFlags) Set(value string) error {
+	if value == "" {
+		return nil
+	}
+	parts := strings.SplitN(value, "=", 2)
+	if len(parts) != 2 {
+		return fmt.Errorf("invalid key-value pair: %s, expected format key=value", value)
+	}
+	key := strings.TrimSpace(parts[0])
+	value = strings.TrimSpace(parts[1])
+	if key == "" || value == "" {
+		return fmt.Errorf("key and value must not be empty: %s", value)
+	}
+	kv := KeyValue{Key: key, Value: value}
+	*i = append(*i, kv)
+	return nil
+}

--- a/render/kv_test.go
+++ b/render/kv_test.go
@@ -1,0 +1,93 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package render
+
+import (
+	"testing"
+)
+
+func TestKeyValueFlags_Set(t *testing.T) {
+	var kvs KeyValueFlags
+
+	tests := []struct {
+		input   string
+		wantErr bool
+		wantLen int
+		wantKey string
+		wantVal string
+	}{
+		{"foo=bar", false, 1, "foo", "bar"},
+		{"baz=qux", false, 2, "baz", "qux"},
+		{"", false, 2, "", ""},
+		{"invalidpair", true, 2, "", ""},
+		{"=novalue", true, 2, "", ""},
+		{"nokey=", true, 2, "", ""},
+	}
+
+	for _, tt := range tests {
+		err := kvs.Set(tt.input)
+		if tt.wantErr && err == nil {
+			t.Errorf("Set(%q) expected error, got nil", tt.input)
+		}
+		if !tt.wantErr && err != nil {
+			t.Errorf("Set(%q) unexpected error: %v", tt.input, err)
+		}
+		if len(kvs) != tt.wantLen {
+			t.Errorf("Set(%q) expected len %d, got %d", tt.input, tt.wantLen, len(kvs))
+		}
+		if tt.wantKey != "" && tt.wantVal != "" {
+			found := false
+			for _, kv := range kvs {
+				if kv.Key == tt.wantKey && kv.Value == tt.wantVal {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("Set(%q) expected key-value (%q,%q) not found", tt.input, tt.wantKey, tt.wantVal)
+			}
+		}
+	}
+}
+
+func TestKeyValueFlags_Get(t *testing.T) {
+	var kvs KeyValueFlags
+	kvs = append(kvs, KeyValue{Key: "foo", Value: "bar"})
+	kvs = append(kvs, KeyValue{Key: "baz", Value: "qux"})
+
+	tests := []struct {
+		name string
+		kvs  *KeyValueFlags
+		key  string
+		want string
+	}{
+		{"existing key", &kvs, "foo", "bar"},
+		{"another key", &kvs, "baz", "qux"},
+		{"missing key", &kvs, "notfound", ""},
+		{"nil receiver", nil, "foo", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.kvs.Get(tt.key)
+			if got != tt.want {
+				t.Errorf("Get(%q) = %q, want %q", tt.key, got, tt.want)
+			}
+		})
+	}
+}

--- a/render/render.go
+++ b/render/render.go
@@ -50,13 +50,14 @@ The source code is available at %s with link to the repo for the source code.
 
 var goModCache = filepath.Join(build.Default.GOPATH, "pkg", "mod")
 
-func Template(dependencies *dependency.List, templatePath, outputPath string) error {
+func Template(dependencies *dependency.List, templateValues KeyValueFlags, templatePath, outputPath string) error {
 	funcMap := template.FuncMap{
 		"currentYear":      CurrentYear,
 		"line":             Line,
 		"licenceText":      LicenceText,
 		"revision":         Revision,
 		"canonicalVersion": CanonicalVersion,
+		"TemplateValue":    templateValues.Get,
 	}
 	tmpl, err := template.New(filepath.Base(templatePath)).Funcs(funcMap).ParseFiles(templatePath)
 	if err != nil {
@@ -96,10 +97,11 @@ var (
 // and discards any additional metadata from the version string.
 //
 // For example:
-//   v1    => v1.0.0
-//   v1.2  => v1.2.0
-//   v1.2.3+incompatible => v1.2.3
-//   v1.2.3-20200707-123456abc => v1.2.3
+//
+//	v1    => v1.0.0
+//	v1.2  => v1.2.0
+//	v1.2.3+incompatible => v1.2.3
+//	v1.2.3-20200707-123456abc => v1.2.3
 func CanonicalVersion(in string) string {
 	matches := regexCanonical.FindStringSubmatch(in)
 	version := regexGroup(regexCanonical, "version", matches)
@@ -110,8 +112,9 @@ func CanonicalVersion(in string) string {
 // If the string does not match this pattern an empty string is returned.
 //
 // For example:
-//   v1.2.3  =>
-//   v1.2.3-20200707-123456abc => 123456abc
+//
+//	v1.2.3  =>
+//	v1.2.3-20200707-123456abc => 123456abc
 func Revision(in string) string {
 	matches := regexRevision.FindStringSubmatch(in)
 	return regexGroup(regexRevision, "revision", matches)


### PR DESCRIPTION
This PR allows additional variables to be injected into the generated documentation.

For example:

```bash
--template-value=eckVersion=x.x.x
```

with the following template:

```md
This page lists the third-party dependencies used to build {{`{{eck}}`}} version {{TemplateValue "eckVersion"}}.
```

generates:

```
This page lists the third-party dependencies used to build {{eck}} version x.x.x.
```