### PR TITLE
Allow any go 1.24 release

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.elastic.co/go-licence-detector
 
-go 1.24.5
+go 1.24
 
 require (
 	github.com/cyphar/filepath-securejoin v0.4.1


### PR DESCRIPTION
If someone happens to come around with go 1.24.4, they should not be completely blocked from compiling this program.

Actually blocks the build for nix at this time because the update is still in staging.

```
Running phase: unpackPhase
unpacking source archive /nix/store/m6xgjwkvm9pazqqinxc5rlslkpb4j9h1-source
source root is source
Running phase: patchPhase
Running phase: updateAutotoolsGnuConfigScriptsPhase
Running phase: configurePhase
Running phase: buildPhase
go: go.mod requires go >= 1.24.5 (running go 1.24.4; GOTOOLCHAIN=local)
error: build of '/nix/store/qf56qjjnrdyjq446kgqavjdgrp2pyl4k-go-licence-detector-0.9.0-go-modules.drv' on 'ssh-ng://amy.dse.in.tum.de' failed: builder for '/nix/store/qf56qjjnrdyjq446kgqavjdgrp2pyl4k-go-licence-detector-0.9.0-go-modules.drv' failed with exit code 1;
```